### PR TITLE
chore: add discourse badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 Install go-libp2p from npm as a dependency of your project
 ========================================================
 
-[![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://ipn.io)
+[![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://protocol.ai)
 [![](https://img.shields.io/badge/project-libp2p-yellow.svg?style=flat-square)](http://libp2p.io/)
 [![](https://img.shields.io/badge/freenode-%23libp2p-yellow.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23libp2p)
+[![Discourse posts](https://img.shields.io/discourse/https/discuss.libp2p.io/posts.svg)](https://discuss.libp2p.io)
+[![Dependency Status](https://david-dm.org/libp2p/npm-go-libp2p-dep.svg?style=flat-square)](https://david-dm.org/libp2p/npm-go-libp2p-dep)
+[![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/feross/standard)
 
 > Install the latest [go-libp2p](https://github.com/libp2p/go-libp2p/) binary from IPFS public gateway.
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "go-platform": "^1.0.0",
     "gunzip-maybe": "^1.4.1",
     "request": "^2.88.0",
-    "tar-fs": "^1.16.3",
+    "tar-fs": "^2.0.0",
     "unzip-stream": "^0.3.0"
   },
   "keywords": [
@@ -34,9 +34,9 @@
   },
   "homepage": "https://github.com/libp2p/npm-go-libp2p-dep",
   "devDependencies": {
-    "rimraf": "^2.6.2",
+    "rimraf": "^2.6.3",
     "standard": "^12.0.1",
     "tap-spec": "^5.0.0",
-    "tape": "^4.9.1"
+    "tape": "^4.10.1"
   }
 }


### PR DESCRIPTION
In the context of [libp2p/libp2p#74](https://github.com/libp2p/libp2p/issues/74), the badge for [discuss.libp2p.io](http://discuss.libp2p.io) was added.

Dependencies were also updated.