### PR TITLE
chore: add 0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,20 @@ $ go install ./...
 $ gox -osarch="linux/amd64 darwin/amd64 windows/amd64" github.com/libp2p/go-libp2p-daemon/p2pd
 ```
 
+- Rename each binary to p2pd in a different folder
+
+```
+$ mv p2pd_linux_amd64 p2pd
+$ mv p2pd_darwin_amd64 p2pd
+$ mv p2pd_windows_amd64.exe p2pd.exe
+```
+
 - Archive resulting binaries
 
 ```sh
-$ tar -cvzf go-libp2p-0.1.0-linux.tar.gz p2pd_linux_amd64
-$ tar -cvzf go-libp2p-0.1.0-mac.tar.gz p2pd_darwin_amd64
-$ zip go-libp2p-0.1.0-windows.zip p2pd_windows_amd64.exe
+$ tar -cvzf go-libp2p-0.1.0-linux.tar.gz p2pd
+$ tar -cvzf go-libp2p-0.1.0-mac.tar.gz p2pd
+$ zip go-libp2p-0.1.0-windows.zip p2pd.exe
 ```
 
 - Add to IPFS (a daemon should be running)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "go-libp2p-dep",
-  "version": "6.0.30",
+  "version": "0.1.0",
   "description": "Install the latest go-libp2p binary",
   "leadMaintainer": "Vasco Santos <santos.vasco10@gmail.com>",
   "main": "src/index.js",

--- a/src/versions.js
+++ b/src/versions.js
@@ -2,6 +2,12 @@
 
 // map version to ipfs cid
 module.exports = {
+  'v0.1.0': {
+    'darwin': 'QmajN9chpFzG4msziqEKRbF32VW87a5SeKRKXiao6qokVT',
+    'linux': 'QmaX7i8cFkVoN8FmgLhNaxfapkQrztpuChdMRgcYDZQmq1',
+    'win32': 'Qme6SrCD6fm8AFmH9kA5BYwyz3fBq2QjrsxePen5Xoy9R1'
+  },
+  // Old gx format releases
   'v6.0.30': {
     'darwin': 'QmSS6iQ3JNJ96g73tFARAcdYaMmAsvjX1RVuMPqJThTs7D',
     'linux': 'Qmdu8WCFUW43u8mHpbj2jV2ZSB1mP7JcjnJJcJ1oF6iMwW',


### PR DESCRIPTION
Added the new `go-libp2p` v0.1.0 to the versions. It is important pointing out that, with the `go-libp2p` change from `gx` to `gomod` the versioning was restarted.

Other than that, the documentation for adding a new version was updated, as the binary file that gets archived must be named `p2pd`.