### PR TITLE
chore: add 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "go-libp2p-dep",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Install the latest go-libp2p binary",
   "leadMaintainer": "Vasco Santos <santos.vasco10@gmail.com>",
   "main": "src/index.js",

--- a/src/versions.js
+++ b/src/versions.js
@@ -2,6 +2,11 @@
 
 // map version to ipfs cid
 module.exports = {
+  'v0.4.0': {
+    'darwin': 'QmXTAqBwpuAyYTsWD7gZ1MBq77cWmkeh1Lm8e286P47C7C',
+    'linux': 'QmZwvFy5e3RrxD39DcXLGHfhsga8uMEU3JpKKVbHfkcCdv',
+    'win32': 'QmdCyyCxLgAD3hNLAgYDRioKufPkyr5ggGnPokkW9FcfcZ'
+  },
   'v0.3.1': {
     'darwin': 'QmettTVLnaLaVF9DzKd2yik8fnGZ1rbK7PuHBF8eqB2Yft',
     'linux': 'QmQdVisPPnESnvQYmify1AEULwG5puXQq1c6yQyD4AVCJd',


### PR DESCRIPTION
Add `0.4.0` version of `go-libp2p`