### PR TITLE
chore: upgrade go-libp2p-0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "go-libp2p-dep",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Install the latest go-libp2p binary",
   "leadMaintainer": "Vasco Santos <santos.vasco10@gmail.com>",
   "main": "src/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -67,6 +67,7 @@ function download (version, platform) {
 
     // Start
     process.stdout.write(`Platform: ${platform}\n`)
+    process.stdout.write(`Version: ${version}\n`)
     process.stdout.write(`Downloading: ${url}\n`)
     process.stdout.write(`Destination: ${installPath}\n`)
 

--- a/src/versions.js
+++ b/src/versions.js
@@ -2,6 +2,11 @@
 
 // map version to ipfs cid
 module.exports = {
+  'v0.5.0': {
+    'darwin': 'Qmeb9fK9DVYWHDXCknr6zEYAzvchKTYa11sr27QXjrxzFC',
+    'linux': 'QmW7d5CMmo6GPuRFWXXweSvMB3odzy3dxEHz4Y1HCKhfiB',
+    'win32': 'QmUSrv5k8zay7eYzr7hgrrgeqDHthzf7Kg91RkEuRoxWDC'
+  },
   'v0.4.0': {
     'darwin': 'QmXTAqBwpuAyYTsWD7gZ1MBq77cWmkeh1Lm8e286P47C7C',
     'linux': 'QmZwvFy5e3RrxD39DcXLGHfhsga8uMEU3JpKKVbHfkcCdv',


### PR DESCRIPTION
Add `0.5.0` version of `go-libp2p` per https://github.com/libp2p/go-libp2p-daemon/releases/tag/v0.2.3