### PR TITLE
chore: upgrade go-libp2p-0.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "go-libp2p-dep",
-  "version": "0.5.0",
+  "version": "0.8.1",
   "description": "Install the latest go-libp2p binary",
   "leadMaintainer": "Vasco Santos <santos.vasco10@gmail.com>",
   "main": "src/index.js",

--- a/src/versions.js
+++ b/src/versions.js
@@ -2,6 +2,11 @@
 
 // map version to ipfs cid
 module.exports = {
+  'v0.8.1': {
+    'darwin': 'QmSSvbrXjWNfTmTZ3Xe1jqpFXdo5iFxEn8EsviuDFTeUdy',
+    'linux': 'QmZTzykGoDz16apo8fVJ7mBYfpyWnqnqwDaJgtC34UbttR',
+    'win32': 'QmcMnz8bFneUhW87e8iaP3Cjpd7ZwyhB31JfwRnnoGrd2X'
+  },
   'v0.5.0': {
     'darwin': 'Qmeb9fK9DVYWHDXCknr6zEYAzvchKTYa11sr27QXjrxzFC',
     'linux': 'QmW7d5CMmo6GPuRFWXXweSvMB3odzy3dxEHz4Y1HCKhfiB',


### PR DESCRIPTION
Add `0.8.1` version of `go-libp2p` per https://github.com/libp2p/go-libp2p-daemon/releases/tag/v0.2.4