### PR TITLE
fix: add retry

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "go-platform": "^1.0.0",
     "gunzip-maybe": "^1.4.1",
+    "p-retry": "^4.6.1",
     "request": "^2.88.0",
     "tar-fs": "^2.0.0",
     "unzip-stream": "^0.3.0"

--- a/src/versions.js
+++ b/src/versions.js
@@ -5,7 +5,7 @@ module.exports = {
   'v0.11.0': {
     'darwin': 'QmbRgQrwZFyR6cjwuN6dgSfadmr9KrLmM72hRJ1B3K6659',
     'linux': 'QmW6hANCx63LR2Unb8TWwB7UkDC2SNKUV5QbaWzSyjsoPf',
-    'win32': 'QmW9zNiN8VL59UbC2DmStQoxdy7TTnZfNsTXBVSn9NR9Wy',
+    'win32': 'QmW9zNiN8VL59UbC2DmStQoxdy7TTnZfNsTXBVSn9NR9Wy'
   },
   'v0.8.1': {
     'darwin': 'QmSSvbrXjWNfTmTZ3Xe1jqpFXdo5iFxEn8EsviuDFTeUdy',


### PR DESCRIPTION
Downloading from ipfs.io is unreliable with intermittant failures around the remote socket being closed.

Add a retry configurable via the `GO_LIBP2P_DEP_DOWNLOAD_RETRIES` env var.

Fixes this sort of thing, seen in CI very frequently:

```
npm ERR! code 1
npm ERR! path /home/runner/work/js-libp2p/js-libp2p/node_modules/go-libp2p-dep
npm ERR! command failed
npm ERR! command sh -c node src/bin.js
npm ERR! Platform: linux
npm ERR! Version: v0.11.0
npm ERR! Downloading: ipfs.io/ipfs/QmW6hANCx63LR2Unb8TWwB7UkDC2SNKUV5QbaWzSyjsoPf
npm ERR! Destination: /home/runner/work/js-libp2p/js-libp2p/node_modules/go-libp2p-dep/go-libp2p
npm ERR! Error: aborted
npm ERR! Download failed!
```