### PR TITLE
chore: default to latest version

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -36,10 +36,18 @@ function download (version, platform) {
 
     const isWindows = platform === 'win32'
 
+    let libp2pVersion = libp2pVersions[version]
+
+    if (!libp2pVersion) {
+      version = libp2pVersions.latest
+    }
+
+    libp2pVersion = libp2pVersions[libp2pVersions.latest]
+
     // Create the download url
     const fileExtension = isWindows ? '.zip' : '.tar.gz'
     const fileName = 'libp2p_' + version + fileExtension
-    const url = `${distUrl}/ipfs/${libp2pVersions[version][platform]}`
+    const url = `${distUrl}/ipfs/${libp2pVersion[platform]}`
 
     // Success callback wrapper
     // go-libp2p contents are in 'go-libp2p/', so append that to the path

--- a/src/versions.js
+++ b/src/versions.js
@@ -2,6 +2,7 @@
 
 // map version to ipfs cid
 module.exports = {
+  latest: 'v0.11.0',
   'v0.11.0': {
     'darwin': 'QmbRgQrwZFyR6cjwuN6dgSfadmr9KrLmM72hRJ1B3K6659',
     'linux': 'QmW6hANCx63LR2Unb8TWwB7UkDC2SNKUV5QbaWzSyjsoPf',


### PR DESCRIPTION
Decouples package version from go-libp2p release version